### PR TITLE
Fix Vercel config: replace routes with rewrites and headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,19 +10,10 @@
       }
     }
   ],
-  "routes": [
+  "rewrites": [
     {
-      "src": "/assets/(.*)",
-      "headers": {
-        "cache-control": "max-age=31536000, immutable"
-      }
-    },
-    {
-      "handle": "filesystem"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "source": "/((?!assets/).*)",
+      "destination": "/index.html"
     }
   ],
   "headers": [
@@ -40,6 +31,15 @@
         {
           "key": "X-XSS-Protection",
           "value": "1; mode=block"
+        }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "max-age=31536000, immutable"
         }
       ]
     },


### PR DESCRIPTION
<h3>Update from the Builder.io Visual Editor.</h3>
<p>The builder.io bot is busy generating a detailed description...</p>
<p align='left'><img src='https://cdn.builder.io/api/v1/file/assets%2FYJIGb4i01jvw0SRdL5Bt%2F848ca4d0600646539f0d46e1e6b1f0d3' width='32' height='32'></p>
<p>tag @builderio-bot for anything you want the bot to do</p>
<p>To clone this PR locally use the <a href="https://cli.github.com/">GitHub CLI</a> with command <code>gh pr checkout 6</code></p>
<!--<projectId>4cde812d5b174c71b3357cc610ea5bc6</projectId>-->
<!--<branchName>spark-home</branchName>-->

## Summary by Sourcery

Synchronise site updates from the Builder.io visual editor and adjust Vercel deployment configuration accordingly.

Deployment:
- Update Vercel deployment configuration in vercel.json

Chores:
- Import content and layout changes from Builder.io visual editor